### PR TITLE
fix(docker-cloud): specify build context for setting up results repository

### DIFF
--- a/docker-cloud/README.md
+++ b/docker-cloud/README.md
@@ -133,7 +133,7 @@ In this step, you're going to build two GitHub repositories - one for the **voti
 
 6. Select "Click here to customize the build settings" to configure the build rules.
 
-7. Under **Dockerfile location** enter **/results/Dockerfile** .
+7. Under **Dockerfile location** enter **Dockerfile** and under **Build Context** enter **/results**.
 
 8. Click **Create** at the bottom of the page.
 


### PR DESCRIPTION
The build would fail because package.json could not be found in the default context '/'
Fixed by specifying correct path to the build context and refactoring the Dockerfile path